### PR TITLE
Fix docs url in service tutorials

### DIFF
--- a/docs/tutorials/create-a-service-to-detect-anomalies-using-a-model-built-from-scratch.md
+++ b/docs/tutorials/create-a-service-to-detect-anomalies-using-a-model-built-from-scratch.md
@@ -608,7 +608,7 @@ class MyService(Service):# (2)!
                 ),
             ],
             has_ai=True,# (8)!
-            docs_url="https://docs.swiss-ai-center.ch/reference/core-concepts/service/", # (9)!
+            docs_url="https://docs.swiss-ai-center.ch/reference/services/ae-ano-detection/", # (9)!
         )
         self._logger = get_logger(settings)
 

--- a/docs/tutorials/create-a-service-to-detect-anomalies-using-a-model-built-from-scratch.md
+++ b/docs/tutorials/create-a-service-to-detect-anomalies-using-a-model-built-from-scratch.md
@@ -157,14 +157,14 @@ These are the dependencies required to create the model to detect anomalies.
 
 Then, install the dependencies:
 
-```sh title="Execute this in the 'model-serving' folder"
+```sh title="Execute this in the 'model-creation' folder"
 # Install the dependencies
 pip install --requirement requirements.txt
 ```
 
 Create a freeze file to pin all dependencies to their current versions:
 
-```sh title="Execute this in the 'model-serving' folder"
+```sh title="Execute this in the 'model-creation' folder"
 # Freeze the dependencies
 pip freeze --local --all > requirements-all.txt
 ```

--- a/docs/tutorials/create-a-service-to-detect-anomalies-using-a-model-built-from-scratch.md
+++ b/docs/tutorials/create-a-service-to-detect-anomalies-using-a-model-built-from-scratch.md
@@ -169,22 +169,6 @@ Create a freeze file to pin all dependencies to their current versions:
 pip freeze --local --all > requirements-all.txt
 ```
 
-The specific
-`common-code @ git+https://github.com/swiss-ai-center/common-code.git@<commit>`
-line will conflict with the more general line in `requirements.txt` due to the
-explicit commit reference.
-
-From there, you have two options:
-
-* **Easier update:** Remove the specific
-  `common-code @ git+https://github.com/swiss-ai-center/common-code.git@<commit>`
-  line from `requirements-all.txt`. This allows for easier updates of the
-  common-code dependency without adjusting service dependencies.
-* **Consistent dependencies:** Remove the generic line in `requirements.txt` to
-  keep dependencies consistent across machines and time. This will ensure that the
-  same versions of the dependencies are installed on every machine if you ever
-  share your code with someone else.
-
 #### Create the source files
 
 Create a `src/train_model.py` file with the following content:

--- a/docs/tutorials/create-a-service-to-rotate-an-image.md
+++ b/docs/tutorials/create-a-service-to-rotate-an-image.md
@@ -186,7 +186,7 @@ This service rotates an image by 90, 180 or 270 degrees clockwise.
 
     This service rotates an image by 90, 180 or 270 degrees clockwise.
 
-    _Check the [related documentation](https://swiss-ai-center.github.io/swiss-ai-center/reference/image-rotate) for more information._
+    _Check the [related documentation](https://docs.swiss-ai-center.ch/reference/services/image-rotate/) for more information._
     ```
 
 #### Update the `pyproject.toml` file
@@ -275,7 +275,7 @@ class MyService(Service):
                 ),
             ],
             has_ai=False,
-            docs_url="https://docs.swiss-ai-center.ch/reference/core-concepts/service/", # (5)!
+            docs_url="https://docs.swiss-ai-center.ch/reference/services/image-rotate/", # (5)!
         )
         self._logger = get_logger(settings)
 

--- a/docs/tutorials/create-a-service-to-summarize-a-text-using-an-existing-model.md
+++ b/docs/tutorials/create-a-service-to-summarize-a-text-using-an-existing-model.md
@@ -186,7 +186,7 @@ This service summarizes a text using the Hugging Face library.
 
     This service summarizes a text using the Hugging Face library.
 
-    _Check the [related documentation](https://swiss-ai-center.github.io/swiss-ai-center/reference/text-summarizer) for more information._
+    _Check the [related documentation](https://docs.swiss-ai-center.ch/reference/services/text-summarizer/) for more information._
     ```
 
 #### Update the `pyproject.toml` file


### PR DESCRIPTION
- **Remove misleading information in model from scratch tutorial**
- **Fix shell commands description**
- **Fix docs url for service**
