### PR TITLE
Use opencv-python-headless for container

### DIFF
--- a/docs/reference/services/image-draw-bounding-boxes.md
+++ b/docs/reference/services/image-draw-bounding-boxes.md
@@ -29,7 +29,6 @@ The JSON file may contain additional fields; they will be ignored.
 ## Tools
 The service uses Pillow to draw the boxes.
 
-
 ## Environment variables
 
 Check the

--- a/docs/reference/services/text-recognition-ocr.md
+++ b/docs/reference/services/text-recognition-ocr.md
@@ -23,7 +23,6 @@ This service uses Tesseract through
 Tesseract 5, head to its
 [github page](https://github.com/tesseract-ocr/tesseract/releases).
 
-
 ## Environment variables
 
 Check the

--- a/docs/tutorials/create-a-service-to-rotate-an-image.md
+++ b/docs/tutorials/create-a-service-to-rotate-an-image.md
@@ -132,7 +132,7 @@ Update the `requirements.txt` file with the following content:
 ```txt title="requirements.txt" hl_lines="2 3"
 common-code[test] @ git+https://github.com/swiss-ai-center/common-code.git@main
 numpy==1.26.4
-opencv-python-headless==4.9.0.80
+opencv-python==4.9.0.80
 ```
 
 The `common-code` package is required to serve the model over a FastAPI REST API

--- a/docs/tutorials/create-a-service-to-rotate-an-image.md
+++ b/docs/tutorials/create-a-service-to-rotate-an-image.md
@@ -382,18 +382,30 @@ app = FastAPI(
     wanted type of the data, you might need to convert the data to the expected
     type.
 
-#### Update the `Dockerfile` file
+#### Update the `Dockerfile` and `development.Dockerfile` files
 
-Update the Dockerfile to install all required packages that might be required by
+Update the Dockerfiles to install all required packages that might be required by
 the model and the model itself:
 
-```dockerfile title="Dockerfile" hl_lines="5"
+```dockerfile title="Dockerfile" hl_lines="6"
 # Base image
 FROM python:3.11
 
 # Install all required packages to run the model
+# (1)!
 RUN apt update && apt install --yes ffmpeg libsm6 libxext6
 ...
+```
+
+1. Add any additional packages required to run your model.
+
+```dockerfile title="development.Dockerfile" hl_lines="6"
+# Base image
+FROM python:3.11
+
+# Install all required packages to run the model
+# (1)!
+RUN apt update && apt install --yes ffmpeg libsm6 libxext6
 ```
 
 1. Add any additional packages required to run your model.

--- a/docs/tutorials/create-a-service-to-rotate-an-image.md
+++ b/docs/tutorials/create-a-service-to-rotate-an-image.md
@@ -384,8 +384,8 @@ app = FastAPI(
 
 #### Update the `Dockerfile` and `development.Dockerfile` files
 
-Update the Dockerfiles to install all required packages that might be required by
-the model and the model itself:
+Update the Dockerfiles to install all required packages that might be required
+by the model and the model itself:
 
 ```dockerfile title="Dockerfile" hl_lines="6"
 # Base image

--- a/docs/tutorials/create-a-service-to-rotate-an-image.md
+++ b/docs/tutorials/create-a-service-to-rotate-an-image.md
@@ -132,7 +132,7 @@ Update the `requirements.txt` file with the following content:
 ```txt title="requirements.txt" hl_lines="2 3"
 common-code[test] @ git+https://github.com/swiss-ai-center/common-code.git@main
 numpy==1.26.4
-opencv-python==4.9.0.80
+opencv-python-headless==4.9.0.80
 ```
 
 The `common-code` package is required to serve the model over a FastAPI REST API


### PR DESCRIPTION
This avoids the potential error for some users:

ImportError: libGL.so.1: cannot open shared object file: No such file or directory
